### PR TITLE
fix: vite config

### DIFF
--- a/desk/vite.config.js
+++ b/desk/vite.config.js
@@ -106,6 +106,7 @@ export default defineConfig({
       "showdown",
       "tailwind.config.js",
       "prosemirror-state",
+      "lowlight",
     ],
   },
 });


### PR DESCRIPTION
This fix addresses an error encountered while starting frontend development using ```yarn dev ``` - 

<img src="https://github.com/user-attachments/assets/f696b128-cb64-43a0-bfce-cdfb95150e0a" width="75%">


<img src="https://github.com/user-attachments/assets/952733ca-2c75-451a-8106-b3a866237b51" width="75%">

This update ensures proper relative imports and resolves the issue, allowing the frontend to start without errors.